### PR TITLE
Add conversions for metre -> inch, foot, yard

### DIFF
--- a/scripts/unitconverter.js
+++ b/scripts/unitconverter.js
@@ -55,6 +55,14 @@
     unitConverter.addUnit('g', 'pound', 453.59237);
     unitConverter.addUnit('g', 'lb', 453.59237);
 
+	// we use the SI metre unit as the base; this allows
+	// us to convert between SI and English units
+	unitConverter.addUnit('m', 'in', 0.0254);
+	unitConverter.addUnit('m', 'inch', 0.0254);
+	unitConverter.addUnit('m', 'ft', 0.3048);
+	unitConverter.addUnit('m', 'foot', 0.3048);
+	unitConverter.addUnit('m', 'yd', 0.9144);
+	unitConverter.addUnit('m', 'yard', 0.9144);
 
     window.$u = function (value, unit) {
         var u = new window.unitConverter(value, unit);


### PR DESCRIPTION
```
$u(1, "m").as("foot").debug()
"1 m is 3.280839895013123 foot"

$u(1, "m").as("inch").debug()
"1 m is 39.37007874015748 inch"

$u(1, "m").as("yard").debug()
"1 m is 1.0936132983377078 yard"
```

Used the same comment as the part for grams -> ounces, pounds